### PR TITLE
Fix syntax error in declaring variable

### DIFF
--- a/el_pagination/static/el-pagination/js/el-pagination.js
+++ b/el_pagination/static/el-pagination/js/el-pagination.js
@@ -77,7 +77,7 @@
             // On scroll pagination.
             if (settings.paginateOnScroll) {
                 var win = $(window),
-                var doc = $(document);
+                    doc = $(document);
                 doc.scroll(function(){
                     if (doc.height() - win.height() -
                         win.scrollTop() <= settings.paginateOnScrollMargin) {


### PR DESCRIPTION
Typo in declaring the var "doc" in el-pagination.js