### PR TITLE
fixed typo in `endles_chunk_complete`

### DIFF
--- a/el_pagination/static/el-pagination/js/el-pagination.js
+++ b/el_pagination/static/el-pagination/js/el-pagination.js
@@ -87,7 +87,7 @@
                         if (!chunckSize || loadedPages % chunckSize) {
                             element.find(settings.moreSelector).click();
                         } else {
-                            element.find(settings.moreSelector).addClass('endles_chunk_complete');
+                            element.find(settings.moreSelector).addClass('endless_chunk_complete');
                         }
                     }
                 });


### PR DESCRIPTION
The JS attempts to add `endles_chunk_complete` to the class, but it should be (as documented) `endless_chunk_complete`