### PR TITLE
Fix usage of context in Django 1.10

### DIFF
--- a/el_pagination/models.py
+++ b/el_pagination/models.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from django.template import (
-    Context,
     loader,
+    Context,
 )
 from django.utils.encoding import iri_to_uri
 

--- a/el_pagination/models.py
+++ b/el_pagination/models.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 from django.template import (
-    loader,
     Context,
+    loader,
 )
 from django.utils.encoding import iri_to_uri
 
@@ -57,30 +57,30 @@ class ELPage(utils.UnicodeMixin):
 
     def __unicode__(self):
         """Render the page as a link."""
-        context = Context(self.context)
-        context.update({
+        extra_context = {
             'add_nofollow': settings.ADD_NOFOLLOW,
             'page': self,
             'querystring_key': self.querystring_key,
-        })
+        }
         if self.is_current:
             template_name = 'el_pagination/current_link.html'
         else:
             template_name = 'el_pagination/page_link.html'
         template = _template_cache.setdefault(
             template_name, loader.get_template(template_name))
-        return template.render(context)
+        with self.context.push(**extra_context):
+            return template.render(self.context.flatten())
 
 
 class PageList(utils.UnicodeMixin):
     """A sequence of endless pages."""
 
     def __init__(
-            self, request, page, querystring_key,
-            default_number=None, override_path=None, context=None):
+            self, request, page, querystring_key, context,
+            default_number=None, override_path=None):
         self._request = request
         self._page = page
-        self.context = context or {}
+        self.context = context
         self.context['request'] = request
         if default_number is None:
             self._default_number = 1
@@ -176,10 +176,9 @@ class PageList(utils.UnicodeMixin):
                     pages.append(self.last_as_arrow())
                 else:
                     pages.append(self[item])
-            context = Context(self.context)
-            context.update({'pages': pages})
-            return loader.render_to_string('el_pagination/show_pages.html',
-                                           context)
+            template = loader.get_template('el_pagination/show_pages.html')
+            with self.context.push(pages=pages):
+                return template.render(self.context.flatten())
         return ''
 
     def current(self):

--- a/el_pagination/tests/test_models.py
+++ b/el_pagination/tests/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from contextlib import contextmanager
 
+from django.template import Context
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -81,7 +82,7 @@ class PageListTest(TestCase):
             self.get_path_for_page(self.current_number))
         self.pages = el_models.PageList(
             self.request, self.paginator.page(self.current_number),
-            self.page_label)
+            self.page_label, context=Context())
 
     def get_url_for_page(self, number):
         """Return a url for the given page ``number``."""
@@ -117,7 +118,8 @@ class PageListTest(TestCase):
         # Ensure the *paginated* method returns True if the page list contains
         # more than one page, False otherwise.
         page = DefaultPaginator(range(10), 10).page(1)
-        pages = el_models.PageList(self.request, page, self.page_label)
+        pages = el_models.PageList(self.request, page, self.page_label,
+                                   context=Context())
         self.assertFalse(pages.paginated())
         self.assertTrue(self.pages.paginated())
 
@@ -212,14 +214,15 @@ class PageListTest(TestCase):
     def test_page_list_render_just_one_page(self):
         # Ensure nothing is rendered if the page list contains only one page.
         page = DefaultPaginator(range(10), 10).page(1)
-        pages = el_models.PageList(self.request, page, self.page_label)
+        pages = el_models.PageList(self.request, page, self.page_label,
+                                   context=Context())
         self.assertEqual('', utils.text(pages))
 
     def test_different_default_number(self):
         # Ensure the page path is generated based on the default number.
         pages = el_models.PageList(
             self.request, self.paginator.page(2), self.page_label,
-            default_number=2)
+            default_number=2, context=Context())
         self.assertEqual('/', pages.current().path)
         self.assertEqual(self.get_path_for_page(1), pages.first().path)
 
@@ -241,14 +244,16 @@ class PageListTest(TestCase):
     def test_no_previous(self):
         # An empty string is returned if the previous page cannot be found.
         pages = el_models.PageList(
-            self.request, self.paginator.page(1), self.page_label)
+            self.request, self.paginator.page(1), self.page_label,
+            context=Context())
         self.assertEqual('', pages.previous())
 
     def test_no_next(self):
         # An empty string is returned if the next page cannot be found.
         num_pages = self.paginator.num_pages
         pages = el_models.PageList(
-            self.request, self.paginator.page(num_pages), self.page_label)
+            self.request, self.paginator.page(num_pages), self.page_label,
+            context=Context())
         self.assertEqual('', pages.next())
 
     def test_customized_page_list_callable(self):
@@ -267,7 +272,7 @@ class PageListTest(TestCase):
         request = self.factory.get(path)
         next = el_models.PageList(
             request, self.paginator.page(self.current_number),
-            self.page_label).next()
+            self.page_label, context=Context()).next()
         self.assertEqual(path.replace(' ', '%20') + next.url, next.path)
 
     def test_lookup(self):


### PR DESCRIPTION
This upgrades the code to use the new template system introduced in Django 1.8, as support for the old system was removed in Django 1.10.

See https://docs.djangoproject.com/en/1.10/ref/templates/upgrading/#django-template-loader