### PR TITLE
enabble possibility to return 404 in case page is not in range

### DIFF
--- a/doc/customization.rst
+++ b/doc/customization.rst
@@ -65,6 +65,9 @@ Name                                              Default     Description
                                                               this value if you are going to decorate
                                                               generic views using a different variable name
                                                               for the template (e.g. ``template_name``).
+------------------------------------------------- ----------- ----------------------------------------------
+``PAGE_OUT_OF_RANGE_404``                         *False*     If True on page out of range, throw a 404
+                                                              exception, otherwise display the first page
 ================================================= =========== ==============================================
 
 Templates and CSS

--- a/el_pagination/settings.py
+++ b/el_pagination/settings.py
@@ -54,3 +54,7 @@ DEFAULT_CALLABLE_ARROWS = getattr(
 # Template variable name for *page_template* decorator.
 TEMPLATE_VARNAME = getattr(
     settings, 'EL_PAGINATION_TEMPLATE_VARNAME', 'template')
+
+# If page out of range, throw a 404 exception
+PAGE_OUT_OF_RANGE_404 = getattr(
+    settings, 'EL_PAGINATION_PAGE_OUT_OF_RANGE_404', False)

--- a/el_pagination/templatetags/el_pagination_tags.py
+++ b/el_pagination/templatetags/el_pagination_tags.py
@@ -5,6 +5,7 @@ import re
 
 from django import template
 from django.utils.encoding import iri_to_uri
+from django.http import Http404
 
 from el_pagination import (
     models,
@@ -311,6 +312,8 @@ class PaginateNode(template.Node):
             page = paginator.page(page_number)
         except EmptyPage:
             page = paginator.page(1)
+            if settings.PAGE_OUT_OF_RANGE_404:
+                raise Http404('Page out of range')
 
         # Populate the context with required data.
         data = {

--- a/el_pagination/tests/templatetags/test_el_pagination_tags.py
+++ b/el_pagination/tests/templatetags/test_el_pagination_tags.py
@@ -13,13 +13,11 @@ from django.template import (
 )
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.http import Http404
 
 from el_pagination.exceptions import PaginationError
 from el_pagination.models import PageList
-from el_pagination.settings import (
-    PAGE_LABEL,
-    PER_PAGE,
-)
+from el_pagination import settings
 from project.models import make_model_instances
 
 skip_if_old_etree = unittest.skipIf(
@@ -52,7 +50,7 @@ class TemplateTagsTestMixin(object):
         querydict = {} if data is None else data
         querydict.update(kwargs)
         if page is not None:
-            querydict[PAGE_LABEL] = page
+            querydict[settings.PAGE_LABEL] = page
         return self.factory.get(url, querydict)
 
 
@@ -105,7 +103,7 @@ class PaginateTestMixin(TemplateTagsTestMixin):
         # Ensure the queryset is correctly updated.
         template = '{% $tagname objects %}'
         html, context = self.render(self.request(), template)
-        self.assertRangeEqual(range(PER_PAGE), context['objects'])
+        self.assertRangeEqual(range(settings.PER_PAGE), context['objects'])
         self.assertEqual('', html)
 
     def test_per_page_argument(self):
@@ -228,9 +226,18 @@ class PaginateTestMixin(TemplateTagsTestMixin):
 
     def test_invalid_page(self):
         # The first page is displayed if an invalid page is provided.
+        settings.PAGE_OUT_OF_RANGE_404 = False
         template = '{% $tagname 5 objects %}'
         _, context = self.render(self.request(page=0), template)
         self.assertRangeEqual(range(5), context['objects'])
+
+    def test_invalid_page_with_raise_404_enabled(self):
+        # The 404 error is raised if an invalid page is provided and
+        # env variable PAGE_OUT_OF_RANGE_404 is set to True.
+        settings.PAGE_OUT_OF_RANGE_404 = True
+        template = '{% $tagname 5 objects %}'
+        with self.assertRaises(Http404):
+            self.render(self.request(page=0), template)
 
     def test_nested_context_variable(self):
         # Ensure nested context variables are correctly handled.
@@ -355,7 +362,7 @@ class ShowMoreTest(EtreeTemplateTagsTestMixin, TestCase):
         template = '{% paginate objects %}{% show_more %}'
         tree = self.render(self.request(), template)
         link = tree.find('.//a[@class="endless_more"]')
-        expected = '/?{0}={1}'.format(PAGE_LABEL, 2)
+        expected = '/?{0}={1}'.format(settings.PAGE_LABEL, 2)
         self.assertEqual(expected, link.attrib['href'])
 
     def test_page_next_url(self):
@@ -363,7 +370,7 @@ class ShowMoreTest(EtreeTemplateTagsTestMixin, TestCase):
         template = '{% paginate objects %}{% show_more %}'
         tree = self.render(self.request(page=3), template)
         link = tree.find('.//a[@class="endless_more"]')
-        expected = '/?{0}={1}'.format(PAGE_LABEL, 4)
+        expected = '/?{0}={1}'.format(settings.PAGE_LABEL, 4)
         self.assertEqual(expected, link.attrib['href'])
 
     def test_last_page(self):

--- a/tests/develop.py
+++ b/tests/develop.py
@@ -30,7 +30,7 @@ def call(*args):
 
 def pip_install(*args):
     """Install packages using pip inside the virtualenv."""
-    call(WITH_VENV, VENV_NAME, 'pip', 'install', *args)
+    call(WITH_VENV, VENV_NAME, 'pip', 'install', '--use-mirrors', *args)
 
 
 def patch_django_nose():

--- a/tests/develop.py
+++ b/tests/develop.py
@@ -30,7 +30,7 @@ def call(*args):
 
 def pip_install(*args):
     """Install packages using pip inside the virtualenv."""
-    call(WITH_VENV, VENV_NAME, 'pip', 'install', '--use-mirrors', *args)
+    call(WITH_VENV, VENV_NAME, 'pip', 'install', *args)
 
 
 def patch_django_nose():

--- a/tests/requirements.pip
+++ b/tests/requirements.pip
@@ -1,7 +1,6 @@
 # Django Endless Pagination test requirements.
 # Dependencies are installed by the ``make`` command.
 
-django==1.10.2
 coverage==4.2
 django-nose==1.4.4
 flake8==2.6.2

--- a/tests/requirements.pip
+++ b/tests/requirements.pip
@@ -1,6 +1,7 @@
 # Django Endless Pagination test requirements.
 # Dependencies are installed by the ``make`` command.
 
+django==1.10.2
 coverage==4.2
 django-nose==1.4.4
 flake8==2.6.2


### PR DESCRIPTION
By default if the page is out of range, the first page is displayed. 

On our website we have 'clusters' that change in length as time goes by that means that the number of pages of the pagination can be reduced. It can happen that google indexes our pages therefore we don't want to be in the situation when the last page (that was indexed but no longer has content) returns the same content as the first page (default behaviour), but instead return the first page with a 404 status code. For this I created an env variable that enables the raising of a 404 error.

If you have any better ideas on how to implement this without altering your code, please share.