### PR TITLE
Fixed rel=nofollow generation

### DIFF
--- a/el_pagination/templates/el_pagination/next_link.html
+++ b/el_pagination/templates/el_pagination/next_link.html
@@ -1,4 +1,4 @@
 <a href="{{ page.path }}"
    rel="next"
-   data-el-querystring-key="{{ querystring_key }}{% if add_nofollow %} nofollow{% endif %}"
+   data-el-querystring-key="{{ querystring_key }}"{% if add_nofollow %} rel="nofollow"{% endif %}
    class="endless_page_link">{{ page.label|safe }}</a>

--- a/el_pagination/templates/el_pagination/page_link.html
+++ b/el_pagination/templates/el_pagination/page_link.html
@@ -1,3 +1,3 @@
 <a href="{{ page.path }}"
-    data-el-querystring-key="{{ querystring_key }}{% if add_nofollow %} nofollow{% endif %}"
+    data-el-querystring-key="{{ querystring_key }}"{% if add_nofollow %} rel="nofollow"{% endif %}
     class="endless_page_link">{{ page.label|safe }}</a>

--- a/el_pagination/templates/el_pagination/previous_link.html
+++ b/el_pagination/templates/el_pagination/previous_link.html
@@ -1,4 +1,4 @@
 <a href="{{ page.path }}"
    rel="prev"
-   data-el-querystring-key="{{ querystring_key }}{% if add_nofollow %} nofollow{% endif %}"
+   data-el-querystring-key="{{ querystring_key }}"{% if add_nofollow %} rel="nofollow"{% endif %}
    class="endless_page_link">{{ page.label|safe }}</a>


### PR DESCRIPTION
Are there any downsides of additionally using a different template variable (through `or`) that can be set per view or per pagination? I'm currently is a situation where I want to add nofollow not to all pagination links, but just to some paginations. Something like `{% if add_nofollow or el_pagination_add_nofollow %} rel="nofollow"{% endif %}`?