### PR TITLE
Test with pytest-django instead of nose

### DIFF
--- a/tests/requirements.pip
+++ b/tests/requirements.pip
@@ -2,12 +2,12 @@
 # Dependencies are installed by the ``make`` command.
 
 codecov
-coverage==4.3.4
-django-nose==1.4.6
+coverage==6.4.1
 flake8
 isort==4.3.21
 ipdb
-nose==1.3.7
+pytest
+pytest-django
 selenium<4.0
 sphinx==1.5.5
 #xvfbwrapper==0.2.9

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -25,8 +25,6 @@ DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3'}}
 INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'el_pagination',
-    'nose',
-    'django_nose',
     PROJECT_NAME,
 )
 gettext = lambda s: s
@@ -38,7 +36,6 @@ SECRET_KEY = os.getenv('EL_PAGINATION_SECRET_KEY', 'secret')
 SITE_ID = 1
 STATIC_ROOT = os.path.join(PROJECT, 'static')
 STATIC_URL = '/static/'
-
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -70,16 +67,7 @@ MIDDLEWARE = (
 )
 
 # Testing.
-NOSE_ARGS = (
-    '--verbosity=1',
-    '--stop',
-    '-s',  # Don't capture stdout (any stdout output will be printed immediately) [NOSE_NOCAPTURE]
-    # '--nomigrations',
-    # '--with-coverage',
-    # '--cover-branches',
-    # '--cover-package=el_pagination',
-)
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+DJANGO_SETTINGS_MODULE = 'test.settings'
 
 try:
     from settings_local import *  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,10 @@ envlist = py35-dj{111,22}
           lint
 
 
+[pytest]
+DJANGO_SETTINGS_MODULE = test.settings
+python_files = tests.py test_*.py *_tests.py
+
 ###########################
 # Default testenv
 ###########################
@@ -34,6 +38,7 @@ basepython = python3.8
 commands =
     flake8
     isort --check-only -df
+    pytest
 
 ###########################
 # Run docs builder


### PR DESCRIPTION
Nose is deprecated and will not work on Python > 3.8 so let's try to switch to https://pypi.org/project/pytest-django