### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/generic_views.rst
+++ b/doc/generic_views.rst
@@ -93,7 +93,7 @@ If the developer wants pagination of publishers, in *views.py* we have code clas
         template_name = "myapp/publisher_list.html"
         context_object_name = "publisher_list"
 
-or fuction-based::
+or function-based::
 
     def entry_index(request, template='myapp/publisher_list.html'):
         context = {

--- a/doc/thanks.rst
+++ b/doc/thanks.rst
@@ -4,7 +4,7 @@ Thanks
 This application was initially inspired by the excellent tool
 *django-pagination* (see https://github.com/ericflo/django-pagination).
 
-Thanks to Francesco Banconi for improving previos version of this application
+Thanks to Francesco Banconi for improving previous version of this application
 (django-endless-pagination)
 
 Thanks to Jannis Leidel for improving the application with some new features,

--- a/doc/twitter_pagination.rst
+++ b/doc/twitter_pagination.rst
@@ -13,7 +13,7 @@ entries of a blog post, in *views.py* we have class-based::
         def get_queryset(self):
             return Entry.objects.all()
 
-or fuction-based::
+or function-based::
 
     def entry_index(request, template='myapp/entry_list.html'):
         context = {
@@ -55,7 +55,7 @@ to put the page template name in the context.
         def get_queryset(self):
             return Entry.objects.all()
 
-or fuction-based::
+or function-based::
 
     def entry_list(request,
         template='myapp/entry_list.html',

--- a/el_pagination/models.py
+++ b/el_pagination/models.py
@@ -112,7 +112,7 @@ class PageList(object):
 
     def __getitem__(self, value):
         # The type conversion is required here because in templates Django
-        # performs a dictionary lookup before the attribute lokups
+        # performs a dictionary lookup before the attribute lookups
         # (when a dot is encountered).
         try:
             value = int(value)

--- a/el_pagination/tests/integration/__init__.py
+++ b/el_pagination/tests/integration/__init__.py
@@ -118,7 +118,7 @@ class SeleniumTestCase(StaticLiveServerTestCase):
         path = '{0}?{1}'.format(url, querydict.urlencode())
 
         # the following javascript scrolls down the entire page body.  Since Twitter
-        # uses "inifinite scrolling", more content will be added to the bottom of the
+        # uses "infinite scrolling", more content will be added to the bottom of the
         # DOM as you scroll... since it is in the loop, it will scroll down up to 100
         # times.
         # for _ in range(100):

--- a/el_pagination/views.py
+++ b/el_pagination/views.py
@@ -22,7 +22,7 @@ class MultipleObjectMixin(object):
     def get_queryset(self):
         """Get the list of items for this view.
 
-        This must be an interable, and may be a queryset
+        This must be an iterable, and may be a queryset
         (in which qs-specific behavior will be enabled).
 
         See original in ``django.views.generic.list.MultipleObjectMixin``.


### PR DESCRIPTION
There are small typos in:
- doc/generic_views.rst
- doc/thanks.rst
- doc/twitter_pagination.rst
- el_pagination/models.py
- el_pagination/tests/integration/__init__.py
- el_pagination/views.py

Fixes:
- Should read `function` rather than `fuction`.
- Should read `previous` rather than `previos`.
- Should read `lookups` rather than `lokups`.
- Should read `iterable` rather than `interable`.
- Should read `infinite` rather than `inifinite`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md