### PR TITLE
tox: pass_env keys must be on separate lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,10 @@ envlist = py35-dj{111,22}
 ###########################
 
 [testenv]
-passenv = CI TRAVIS USE_SELENIUM TRAVIS_*
+passenv =
+    CI
+    USE_SELENIUM
+
 deps =
     -r{toxinidir}/tests/requirements.pip
     dj111: Django>=1.11,<2.0


### PR DESCRIPTION
https://tox.wiki/en/latest/upgrading.html#packaging-configuration-and-inheritance

Drop Travis CI because it is no longer used.