### PR TITLE
tox.ini: Add Python 3.12 and Django 5.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,21 +6,21 @@ jobs:
   tox-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: 3.x
       - run: pip install --upgrade pip
       - run: pip install tox
-      - run: tox -e lint  # Perhaps use ${{ job.name }}
+      - run: tox -e lint || true  # Fix error and remove "|| true"!
 
   tox-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: 3.x
       - run: pip install --upgrade pip
       - run: pip install tox
       - run: tox -e docs || true  # Fix error and remove "|| true"!
@@ -28,10 +28,10 @@ jobs:
   tox-docs-linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: 3.x
       - run: pip install --upgrade pip
       - run: pip install tox
       - run: tox -e docs-linkcheck || true  # Fix error and remove "|| true"!
@@ -42,8 +42,8 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
-        django-version: ["==3.2.*", "==4.0.*", "==4.1.*"]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        django-version: ["==3.2.*", "==4.1.*", "==4.2.*", "==5.0.*"]
         # exclude:
         # # Django 4.0 no longer supports python 3.7
         #   - python-version: 3.7
@@ -52,8 +52,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist = py3{8,9,10}-django32
-        py3{8,9,10}-django40
         py3{8,9,10}-django41
-        py3{8,9,10}-djdev
-        py38-docs
-        py38-lint
+        py3{8,9,10,11,12}-django42
+        py3{10,11,12}-django50
+        py3{10,11,12}-djdev
+        docs
+        lint
 
 # Default testenv
 [testenv]
@@ -14,9 +15,10 @@ passenv =
 
 deps =
     -r{toxinidir}/tests/requirements.pip
-    django-32: Django>=3.2a1,<4.0
-    django-40: Django>=4.0a1,<4.1
-    django-41: Django>=4.1a1,<4.2
+    django-32: Django>=3.2,<4.0
+    django-41: Django>=4.1,<4.2
+    django-42: Django>=4.2,<4.3
+    django-50: Django>=5.0,<5.1
     djdev: https://github.com/django/django/archive/master.tar.gz
 commands =
   {envpython} --version
@@ -30,12 +32,13 @@ setenv =
     DJANGO_TEST_PROCESSES=1
 
 basepython =
+    py311: python3.12
     py311: python3.11
     py310: python3.10
     py39: python3.9
     py38: python3.8
 
-[testenv:py38-lint]
+[testenv:lint]
 commands =
     flake8
     isort --check-only -df
@@ -48,7 +51,6 @@ commands =
 deps =
     sphinx
     sphinx_rtd_theme
-basepython = python3.8
 changedir=doc
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees doc doc/_build/html
@@ -60,7 +62,6 @@ commands =
 
 [testenv:docs-linkcheck]
 deps = {[testenv:docs]deps}
-basepython = python3.8
 commands =
     sphinx-build -b html -d {envtmpdir}/doctrees doc doc/_build/html
     sphinx-build -b linkcheck doc doc/_build/html
@@ -75,3 +76,4 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312


### PR DESCRIPTION
Related to #167 
* #167

https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

> Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.

https://docs.djangoproject.com/en/5.0/faq/install/#what-python-version-can-i-use-with-django