### PR TITLE
Add Django 5.2 to the supported versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ["==3.2.*", "==4.1.*", "==4.2.*", "==5.0.*", "==5.1.*"]
+        django-version: ["==3.2.*", "==4.1.*", "==4.2.*", "==5.0.*", "==5.1.*", "==5.2.*"]
         exclude:
         # https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
           - python-version: 3.11
@@ -56,10 +56,14 @@ jobs:
             django-version: "==5.0.*"
           - python-version: 3.8
             django-version: "==5.1.*"
+          - python-version: 3.8
+            django-version: "==5.2.*"
           - python-version: 3.9
             django-version: "==5.0.*"
           - python-version: 3.9
             django-version: "==5.1.*"
+          - python-version: 3.9
+            django-version: "==5.2.*"
         # # Django 4.0 no longer supports python 3.7
         #   - python-version: 3.7
         #     django-version: "==4.0.*"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+~~~~~~~~~~
+
+**New feature**: Django 5.2.x support.
+    Django EL(Endless) Pagination now supports Django from 4.2.x to 5.2.x
+
 Version 4.2.0
 ~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py3{8,9,10,11,12}-django42
         py3{12}-django50
         py3{10,11,12,13}-django51
+        py3{10,11,12,13}-django52
         py3{12,13}-djdev
         black
         isort
@@ -19,6 +20,7 @@ deps =
     django-42: Django>=4.2,<4.3
     django-50: Django>=5.0,<5.1
     django-51: Django>=5.1,<5.2
+    django-52: Django>=5.2,<5.3
     djdev: https://github.com/django/django/archive/master.tar.gz
 commands =
   {envpython} --version


### PR DESCRIPTION
Updates the officially supported versions to include Django 5.2. I didn't update the list of supported Python versions because that would be a potentially breaking change since some of them are EOL, or add Django 6.0 support since I figured that would be better handled in a separate PR if desired.

Changes:

* Adds explicit support for Django 5.2 -- it seems like no changes were needed and everything works with 5.2, but it wasn't in the classifiers.
* Adds Django 5.2 to the Tox environments and the GitHub Actions matrix.

